### PR TITLE
publish the container image to the ghcr.io registry when the commit has as a "v" prefixed tag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,8 @@
 name: Build
 on: [push]
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
 jobs:
   build:
     name: Build
@@ -21,3 +24,16 @@ jobs:
           name: Artifacts
           path: |
             *.deb
+      - name: Login to the ${{ env.REGISTRY }} registry
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Push image to the ${{ env.REGISTRY }} registry
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${GITHUB_REF#refs/*/}"
+          docker tag virtualbmc "$IMAGE"
+          docker push "$IMAGE"


### PR DESCRIPTION
an example of this can be seen at https://github.com/rgl/virtualbmc/pkgs/container/virtualbmc

the docker image is being used at https://github.com/rgl/sidero-vagrant as:

https://github.com/rgl/sidero-vagrant/blob/148c5c2abd43afda1123e20021d4a8037a21c68f/lib.rb#L35-L65